### PR TITLE
feat: Todo CRUD 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sandbox/jueun/todo/controller/TodoController.java
+++ b/src/main/java/com/sandbox/jueun/todo/controller/TodoController.java
@@ -1,0 +1,47 @@
+package com.sandbox.jueun.todo.controller;
+
+import com.sandbox.jueun.todo.domain.Todo;
+import com.sandbox.jueun.todo.dto.TodoCreateRequestDto;
+import com.sandbox.jueun.todo.dto.TodoListResponseDto;
+import com.sandbox.jueun.todo.service.TodoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/todos")
+@RestController
+public class TodoController {
+
+    private final TodoService todoService;
+
+    @GetMapping
+    public ResponseEntity<TodoListResponseDto> getTodoList() {
+        List<Todo> result = todoService.getTodoList();
+
+        return ResponseEntity.ok().body(new TodoListResponseDto(result, "정상 영업합니다."));
+    }
+
+    @PostMapping
+    public ResponseEntity<?> postTodo(@RequestBody TodoCreateRequestDto requestDto) {
+        todoService.createTodo(requestDto.getContent());
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{todoId}")
+    public ResponseEntity<?> updateCompleted(@PathVariable long todoId) {
+        todoService.updateCompleted(todoId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{todoId}")
+    public ResponseEntity<?> deleteTodo(@PathVariable long todoId) {
+        todoService.deleteTodo(todoId);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sandbox/jueun/todo/controller/TodoController.java
+++ b/src/main/java/com/sandbox/jueun/todo/controller/TodoController.java
@@ -4,6 +4,7 @@ import com.sandbox.jueun.todo.domain.Todo;
 import com.sandbox.jueun.todo.dto.TodoCreateRequestDto;
 import com.sandbox.jueun.todo.dto.TodoListResponseDto;
 import com.sandbox.jueun.todo.service.TodoService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +26,7 @@ public class TodoController {
     }
 
     @PostMapping
-    public ResponseEntity<?> postTodo(@RequestBody TodoCreateRequestDto requestDto) {
+    public ResponseEntity<?> postTodo(@RequestBody @Valid TodoCreateRequestDto requestDto) {
         todoService.createTodo(requestDto.getContent());
 
         return ResponseEntity.ok().build();

--- a/src/main/java/com/sandbox/jueun/todo/domain/Todo.java
+++ b/src/main/java/com/sandbox/jueun/todo/domain/Todo.java
@@ -1,0 +1,30 @@
+package com.sandbox.jueun.todo.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Todo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean completed;
+
+    public Todo(String content) {
+        this.content = content;
+        this.completed = false;
+    }
+
+    public void togleCompleted() {
+        this.completed = !completed;
+    }
+}

--- a/src/main/java/com/sandbox/jueun/todo/domain/Todo.java
+++ b/src/main/java/com/sandbox/jueun/todo/domain/Todo.java
@@ -24,7 +24,7 @@ public class Todo {
         this.completed = false;
     }
 
-    public void togleCompleted() {
+    public void toggleCompleted() {
         this.completed = !completed;
     }
 }

--- a/src/main/java/com/sandbox/jueun/todo/dto/MessageResponseDto.java
+++ b/src/main/java/com/sandbox/jueun/todo/dto/MessageResponseDto.java
@@ -1,0 +1,10 @@
+package com.sandbox.jueun.todo.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class MessageResponseDto {
+    private final String message;
+}

--- a/src/main/java/com/sandbox/jueun/todo/dto/TodoCreateRequestDto.java
+++ b/src/main/java/com/sandbox/jueun/todo/dto/TodoCreateRequestDto.java
@@ -1,13 +1,12 @@
 package com.sandbox.jueun.todo.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 @NoArgsConstructor
-@Setter
 @Getter
 public class TodoCreateRequestDto {
+    @NotNull
     private String content;
 }

--- a/src/main/java/com/sandbox/jueun/todo/dto/TodoCreateRequestDto.java
+++ b/src/main/java/com/sandbox/jueun/todo/dto/TodoCreateRequestDto.java
@@ -1,0 +1,13 @@
+package com.sandbox.jueun.todo.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Setter
+@Getter
+public class TodoCreateRequestDto {
+    private String content;
+}

--- a/src/main/java/com/sandbox/jueun/todo/dto/TodoListResponseDto.java
+++ b/src/main/java/com/sandbox/jueun/todo/dto/TodoListResponseDto.java
@@ -1,0 +1,19 @@
+package com.sandbox.jueun.todo.dto;
+
+import com.sandbox.jueun.todo.domain.Todo;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TodoListResponseDto {
+
+    public TodoListResponseDto(List<Todo> list, String message) {
+        this.todos = list;
+        this.message = message;
+    }
+
+    private List<Todo> todos;
+
+    private String message;
+}

--- a/src/main/java/com/sandbox/jueun/todo/repository/TodoRepository.java
+++ b/src/main/java/com/sandbox/jueun/todo/repository/TodoRepository.java
@@ -1,0 +1,9 @@
+package com.sandbox.jueun.todo.repository;
+
+import com.sandbox.jueun.todo.domain.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+}

--- a/src/main/java/com/sandbox/jueun/todo/service/TodoService.java
+++ b/src/main/java/com/sandbox/jueun/todo/service/TodoService.java
@@ -1,0 +1,41 @@
+package com.sandbox.jueun.todo.service;
+
+import com.sandbox.jueun.todo.domain.Todo;
+import com.sandbox.jueun.todo.repository.TodoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class TodoService {
+
+    private final TodoRepository todoRepository;
+
+    public List<Todo> getTodoList() {
+       return  todoRepository.findAll();
+    }
+
+    @Transactional
+    public void createTodo(String content) {
+        todoRepository.save(new Todo(content));
+    }
+
+    @Transactional
+    public void updateCompleted(long id) {
+        Todo todo = todoRepository.findById(id).orElseThrow();
+
+        todo.togleCompleted();
+
+        todoRepository.save(todo);
+    }
+
+    @Transactional
+    public void deleteTodo(long id) {
+        Todo todo = todoRepository.findById(id).orElseThrow();
+
+        todoRepository.delete(todo);
+    }
+}

--- a/src/main/java/com/sandbox/jueun/todo/service/TodoService.java
+++ b/src/main/java/com/sandbox/jueun/todo/service/TodoService.java
@@ -27,7 +27,7 @@ public class TodoService {
     public void updateCompleted(long id) {
         Todo todo = todoRepository.findById(id).orElseThrow();
 
-        todo.togleCompleted();
+        todo.toggleCompleted();
 
         todoRepository.save(todo);
     }


### PR DESCRIPTION
## 배운점
### git rebase
- 모든 도메인에서 사용할 webConfig설정이 마무리되지 않았는데, `jueun/feature/todo` 브랜치에서 작업하면서 webConfig 설정을 함.
- 이후에 webConfig 설정을 `jueun` 브랜치에 커밋했으나, `jueun/feature/todo`브랜치의 베이스 커밋은 webConfig 설정 전 커밋인 상황..
- webConfig 이후에 브랜치 생성 후 작업이 맞다고 생각해서 rebase를 사용하여 `jueun/feature/todo` 브랜치의 베이스 커밋을 변경할 수 있었습니다.

### 프로젝트/폴더 구조에 대한 고민
- 이전까지 저의 스프링 프로젝트는 계층별 구조를 선택했으나, 샌드박스 특성상 도메인별로 분리하면 편하게 작업할 수 있을 것이라 판단하여 도메인 중심의 폴더 구조를 선택하였습니다.
- [패키지-구조: 참고 블로그 1](https://velog.io/@jsb100800/Spring-boot-directory-package)
- [패키지-구조: 참고 블로그2](https://velog.io/@sunil1369/Spring-boot-%ED%8C%A8%ED%82%A4%EC%A7%80-%EA%B5%AC%EC%A1%B0)

### Entity Id 생성 전략
```
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;
```
 - @GeneratedValue 생략 시, pk=null로 데이터 삽입 불가...
 - 생성전략 없이 @GeneratedValue 어노테이션 사용 -> 모든 DB에서 사용할 수 있는 TABLE전략
 - MySql은 AUTO 설정 시 IDENTITY다.
 - [id생성전략 참고 블로그](https://newwisdom.tistory.com/90)

### ✏️ 완료한 API
- [x] `GET` /todos
- [x] `POST` /todos
- [x] `PATCH` /todos/{todoId}
- [x] `DELETE` /todos/{todoId}

### 추가 구현 사항
- [ ] interface 작성
- [x] Record 키워드 사용해보기
- [ ] exception handler 작성
- [ ] ...