### PR TITLE
feat: Email 인증 기능 구현

### DIFF
--- a/src/main/java/com/sandbox/hyunwoo/email/controller/EmailController.java
+++ b/src/main/java/com/sandbox/hyunwoo/email/controller/EmailController.java
@@ -1,0 +1,38 @@
+package com.sandbox.hyunwoo.email.controller;
+
+
+import com.sandbox.hyunwoo.email.dto.RequestAuthEmail;
+import com.sandbox.hyunwoo.email.dto.RequestEmail;
+import com.sandbox.hyunwoo.email.service.EmailSendService;
+import com.sandbox.hyunwoo.email.service.EmailVerificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/email")
+public class EmailController {
+
+    private final EmailSendService emailSendService;
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping
+    public ResponseEntity<?> sendCodeToEmail(@Validated @RequestBody RequestEmail requestEmail, BindingResult bindingResult) {
+        log.info("userEmail: {}", requestEmail);
+        return emailSendService.handleEmailSend(requestEmail, bindingResult);
+    }
+
+    @PostMapping("/authentication")
+    public ResponseEntity<?> authCodeVerification(@Validated @RequestBody RequestAuthEmail requestAuthEmail, BindingResult bindingResult) {
+        log.info("입력받은 사용자 Email, AuthCode: {}", requestAuthEmail);
+        return emailVerificationService.handleAuthCodeVerification(requestAuthEmail, bindingResult);
+    }
+}

--- a/src/main/java/com/sandbox/hyunwoo/email/dto/RequestAuthEmail.java
+++ b/src/main/java/com/sandbox/hyunwoo/email/dto/RequestAuthEmail.java
@@ -1,0 +1,22 @@
+package com.sandbox.hyunwoo.email.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class RequestAuthEmail {
+
+    @NotBlank
+    private String authentication;
+    private String email;
+
+    public RequestAuthEmail() {
+    }
+
+    public RequestAuthEmail(String authentication, String email) {
+        this.authentication = authentication;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/sandbox/hyunwoo/email/dto/RequestEmail.java
+++ b/src/main/java/com/sandbox/hyunwoo/email/dto/RequestEmail.java
@@ -1,0 +1,20 @@
+package com.sandbox.hyunwoo.email.dto;
+
+import jakarta.validation.constraints.Email;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class RequestEmail {
+
+    @Email
+    private String email;
+
+    public RequestEmail() {
+    }
+
+    public RequestEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/sandbox/hyunwoo/email/service/EmailSendService.java
+++ b/src/main/java/com/sandbox/hyunwoo/email/service/EmailSendService.java
@@ -1,0 +1,90 @@
+package com.sandbox.hyunwoo.email.service;
+
+
+import com.sandbox.hyunwoo.email.dto.RequestEmail;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.BindingResult;
+
+import java.util.HashMap;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailSendService {
+
+    public static final String EMAIL_TITLE = "Sandbox: 이메일 인증 코드";
+    private final JavaMailSender javaMailSender;
+    private final EmailVerificationService emailVerificationService;
+
+    /// 발신할 이메일 설정
+    public void sendEmailForm(String toEmail, String authCode) {
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setTo(toEmail); // 누구에게 보낼건지
+            helper.setSubject(EMAIL_TITLE); // 이메일 제목
+            helper.setText(htmlContent(authCode), true); // 이메일 본문, true 설정시 html 처리된다
+
+            javaMailSender.send(message);
+            log.info("이메일 발송 성공: {}", message);
+        } catch (Exception e) {
+            log.error("이메일 발송 실패", e);
+            throw new RuntimeException("이메일 발송에 실패했습니다.");
+        }
+    }
+
+    // style 지원이 되지 않아 인라인 CSS로 해결해야함
+    private String htmlContent(String authCode) {
+        return """
+                <!DOCTYPE html>
+                <html lang="ko">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                </head>
+                <body style="font-family: Arial, sans-serif; background-color: #f4f4f9; margin: 0; padding: 0;">
+                    <div style="max-width: 600px; margin: 0 auto; padding: 20px; background-color: #ffffff; border: 1px solid #dddddd; border-radius: 10px;">
+                        <h2 style="color: #2c3e50;">Sandbox에서 보낸 이메일입니다</h2>
+                        <p style="color: #34495e; line-height: 1.6;">안녕하세요, SSAFY 12기 15반입니다</p>
+                        <p style="color: #34495e; line-height: 1.6;">요청하신 이메일 인증 코드는 아래와 같습니다</p>
+                        <br>
+                        <p style="font-size: 24px; font-weight: bold; color: #e74c3c;">인증 코드: <strong>%s</strong></p>
+                        <br>
+                        <p style="color: #34495e; line-height: 1.6;">이 코드를 <strong>5분</strong> 이내에 입력해주세요.</p>
+                        <p style="color: #34495e; line-height: 1.6;">만약 본인이 요청하지 않은 이메일이라면, 이 이메일을 무시하셔도 됩니다.</p>
+                        <br>
+                        <p style="color: #34495e; line-height: 1.6;">문의사항이 있으면 아래로 연락주세요:</p>
+                        <p style="color: #34495e; line-height: 1.6;">SSAFY 12기 15반 김현우</p>
+                        <p style="color: #34495e; line-height: 1.6;">위치: SSAFY 서울캠퍼스</p>
+                        <p style="color: #34495e; line-height: 1.6;">주소: 서울특별시 강남구 테헤란로 212 멀티캠퍼스</p>
+                        <br><br>
+                        <p style="font-size: 12px; color: #7f8c8d;">이 이메일은 자동으로 발송된 이메일입니다.</p>
+                    </div>
+                </body>
+                </html>
+                """.formatted(authCode);
+
+    }
+
+    public ResponseEntity<?> handleEmailSend(RequestEmail requestEmail, BindingResult bindingResult) {
+        HashMap<String, Object> response = new HashMap<>();
+
+        if (bindingResult.hasErrors()) {
+            log.error("잘못된 요청: {}", bindingResult.getAllErrors());
+            return ResponseEntity.badRequest().body("잘못된 이메일 형식입니다.");
+        }
+
+        String authCode = emailVerificationService.generateVerificationCode();
+        emailVerificationService.storeVerificationCode(requestEmail.getEmail(), authCode);
+        sendEmailForm(requestEmail.getEmail(), authCode);
+
+        response.put("isOk", true);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/sandbox/hyunwoo/email/service/EmailVerificationService.java
+++ b/src/main/java/com/sandbox/hyunwoo/email/service/EmailVerificationService.java
@@ -1,0 +1,73 @@
+package com.sandbox.hyunwoo.email.service;
+
+import com.sandbox.hyunwoo.email.dto.RequestAuthEmail;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.BindingResult;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.HashMap;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final SecureRandom random = new SecureRandom();
+    private static final long EXPIRATION_TIME = 5;  // 인증 코드의 만료 시간 (분)
+
+    private final StringRedisTemplate redisTemplate;
+
+    // 6자리 무작위 인증코드 생성
+    public String generateVerificationCode() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 6; i++) {
+            int index = random.nextInt(CHARACTERS.length());
+            sb.append(CHARACTERS.charAt(index));
+        }
+        return sb.toString();
+    }
+
+    public void storeVerificationCode(String email, String code) {
+        log.info("이메일 및 인증코드 저장: 이메일: {}, 코드: {}", email, code);
+        // 이메일 -> 코드 저장, key - value, 지속시간
+        redisTemplate.opsForValue().set(email, code, Duration.ofMinutes(EXPIRATION_TIME));
+    }
+
+    public boolean verifyCode(String email, String authCode) {
+        // 이메일로 저장된 인증 코드 조회
+        String storedCode = redisTemplate.opsForValue().get(email);
+        if (storedCode != null && !storedCode.equals(authCode)) {
+            log.info("인증 실패: 이메일: {}, 저장된 코드: {}, 입력된 코드: {}", email, storedCode, authCode);
+            return false;
+        }
+
+        // 인증 성공 시 저장되어 있던 이메일 삭제
+        log.info("인증 성공: 이메일: {}, 코드: {}", email, authCode);
+        redisTemplate.delete(email);
+        return true;
+    }
+
+    public ResponseEntity<?> handleAuthCodeVerification(RequestAuthEmail requestAuthEmail, BindingResult bindingResult) {
+        HashMap<String, Object> response = new HashMap<>();
+
+        if (bindingResult.hasErrors()) {
+            log.error("잘못된 요청: {}", bindingResult.getAllErrors());
+            return ResponseEntity.badRequest().body("잘못된 요청입니다.");
+        }
+
+        boolean isSuccess = verifyCode(requestAuthEmail.getEmail(), requestAuthEmail.getAuthentication());
+        if (isSuccess) {
+            response.put("isSuccess", true);
+            return ResponseEntity.ok().body(response);
+        }
+
+        response.put("message", "잘못된 접근입니다.");
+        return ResponseEntity.badRequest().body(response);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,34 @@
 spring.application.name=hyunwoo
 
-# ?????? URL (JDBC ??)
-spring.datasource.url=jdbc:mysql://localhost:3306/sandbox
+# \uB370\uC774\uD130\uBCA0\uC774\uC2A4 URL (JDBC \uD615\uC2DD)
+spring.datasource.url=${database.url}
 
-# ?????? ?? ????
-spring.datasource.username=ssafy
+# \uB370\uC774\uD130\uBCA0\uC774\uC2A4 \uC811\uC18D \uC0AC\uC6A9\uC790\uBA85
+spring.datasource.username=${database.user.name}
 
-# ?????? ?? ????
-spring.datasource.password=ssafy
+# \uB370\uC774\uD130\uBCA0\uC774\uC2A4 \uC811\uC18D \uBE44\uBC00\uBC88\uD638
+spring.datasource.password=${database.user.password}
 
-# JDBC ???? ??? MySQL
+# JDBC \uB4DC\uB77C\uC774\uBC84 \uD074\uB798\uC2A4 MySQL
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Google Mail STMP \uC0AC\uC6A9\uC744 \uC704\uD55C \uC0AC\uC6A9
+# \uCC38\uACE0: https://velog.io/@kyungmin/Spring-%EC%9D%B4%EB%A9%94%EC%9D%BC-%EC%9D%B8%EC%A6%9DGoogle
+spring.mail.host=${mail.host}
+spring.mail.port=${mail.port}
+spring.mail.username=${mail.name}
+spring.mail.password=${mail.password}
+
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.timeout=5000
+spring.mail.properties.mail.smtp.writetimeout=5000
+
+spring.mail.auth-code-expiration-millis=1800000
+
+# redis \uC124\uC815
+spring.data.redis.host=${redis.host}
+spring.data.redis.port=${redis.port}
+spring.data.redis.password=${redis.password}


### PR DESCRIPTION
# 구현 사항
Email 인증: 요청받은 이메일의 인증코드 6자리를 생성 후 이메일 - 인증코드 값을 비교하여 일치, 불일치 여부 반환

# 인증 구현 방법
## 저장 방식
이메일, 인증 코드 저장: `Redis`
## 이유
위 2가지를 저장하는 방식에 있어서 DB, Redis(메모리)가 대표적인 선택지 였는데 인증코드는 5분마다 소멸되어 없어져야 하고 
**인증코드는 빠르게 저장하고 응답**, 속도를 위해 `Redis`를 저장소로 선택
DB에 저장하는 방식도 가능하지만 코드 생성 후 5분 뒤 DB삭제 쿼리 작성, 메인 DB 부하가능성 등이 있었습니다.

* 도움받은 곳: https://velog.io/@kyungmin/Spring-%EC%9D%B4%EB%A9%94%EC%9D%BC-%EC%9D%B8%EC%A6%9DGoogle



# 어려웠던 점
처음에는 프론트에서 Email 요청, 그 후 인증코드 요청이 들어왔습니다.
이메일을 받아서 인증코드를 생성하는 것은 가능했으나 인증코드가 들어왔을 때 어떻게 이메일로 일치시키는가? 가장 큰 고민이었습니다. 
처음에는 인증코드 생성할 때 redis에 인증코드, 인증코드 + email을 저장해서 인증코드로 email을 유추해내는 방식 사용했습니다.

이후 의견 제시하여 프론트에서 인증코드를 확인할 때 이메일도 같이 받도록 수정 -> 이메일 - 인증코드 일치 여부를 정확하게 확인이 가능했습니다.


# 배운 점
`JavaMailSender`, `redis`의 설치, 사용 방법을 알 수 있었습니다.


# 개선사항
Paging 처리에서 피드백 받은 점을 개선했습니다.
개선항목: 컨트롤러에서 응답데이터 생성 후 반환 -> servcie에서 응답데이터 생성 후 컨트롤러에 반환


# 부족한 점
로그, 예외 처리: 파이널 프로젝트에서는 `AOP`, `RestControllerAdvice`를 공부해서 더 깔끔한 코드를 작성해보도록 하겠습니다.
테스트코드: 현재 테스트코드가 작성되어있지 않습니다. 따라서 테스트하기 위해선 직접 입력하고 확인했어야 했는데 테스트 코드 작성 방법 배워서 적용해보겠습니다
Pull Request: hyunwoo 브랜치로 옮기고 새 브랜치를 생성했어야 했는데 paging브랜치에서 브랜치를 생성 했던 점...